### PR TITLE
Avoid reversing the list of resource records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.3 (2017-04-36)
+- preserve the order of resource records
+
 ## 0.2 (2017-03-14)
 - add `is_supported_on_this_platform` API
 


### PR DESCRIPTION
The callback accumulates the list of records in reverse. Previously we would return the result reversed, which confuses some DNS resolvers which expect references to always point forwards in the list.

- preserve the order of the resource records.
- prepare to release v0.3