### PR TITLE
Improve the API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
-## 0.3 (2017-04-36)
+## 0.4 (2017-04-26)
+- recursively resolve CNAMES to A/AAAA/...
+
+## 0.3 (2017-04-26)
 - preserve the order of resource records
 
 ## 0.2 (2017-03-14)

--- a/lib/dnssd.ml
+++ b/lib/dnssd.ml
@@ -295,7 +295,7 @@ let common_callback token result = match result with
       end else Hashtbl.replace in_progress_calls token (Ok [ rr ])
     end
 
-let query name ty =
+let query_one name ty =
   match kDNSServiceType_of_q_type ty with
   | Error (`Msg m) -> failwith m
   | Ok ty' ->
@@ -311,6 +311,35 @@ let query name ty =
     Hashtbl.remove in_progress_calls token;
     query_deallocate q;
     result
+
+let query requested_name ty =
+  (* The DNSServiceRef API will return CNAMEs first, without resolving to
+     A/AAAA/... This function recursively resolves the CNAMES while avoiding
+     returning duplicate records. *)
+  (* NB we only return NoSuchRecord if we find no records. This is because it
+     is possible to query a CNAME which exists, but which points to a non-existent
+     record. *)
+  let rec loop acc name ty =
+    let name' = Dns.Name.to_string name in
+    match query_one name' ty with
+    (* When we're recursing, ignore the NoSuchRecord error *)
+    | Error NoSuchRecord when name' <> requested_name -> Ok acc
+    | Error e -> Error e
+    | Ok rrs ->
+      let not_seen_before = List.filter (fun x -> not (List.mem x acc)) rrs in
+      (* If there are any CNAMEs, resolve these too *)
+      let cnames = List.rev @@ List.fold_left (fun acc rr ->
+        match rr.Dns.Packet.rdata with
+        | CNAME name -> name :: acc
+        | _ -> acc
+      ) [] not_seen_before in
+      List.fold_left
+        (fun acc name -> match acc with
+          | Error e -> Error e
+          | Ok acc ->
+            loop acc name ty
+        ) (Ok (acc @ not_seen_before)) cnames in
+  loop [] (Dns.Name.of_string requested_name) ty
 
 module LowLevel = struct
   type query = {


### PR DESCRIPTION
Previously the API was always low-level, in particular it would return a list of "intermediates" i.e. `CNAME`s but not look up the final results. This patch modifies `query` to recursively lookup `CNAME`s to `A`/`AAAA`/... records.

Note that if a `CNAME` exists but the record it points to doesn't, then we will either return `NoSuchDomain` to the whole query if the `DNSServiceRef` knows about the non-existence, or we will return the partial list of `CNAME`s if `DNSServiceRef` provides these before finding out about the non-existence of the target record.