### PR TITLE
Support large result sets

### DIFF
--- a/lib/dnssd.mli
+++ b/lib/dnssd.mli
@@ -86,10 +86,12 @@ module LowLevel: sig
       called without blocking (very much).
       This raises [Cancelled] if the query has been cancelled. *)
 
-  val response: query -> (Dns.Packet.rr list, error) result
+  val response: query -> ((Dns.Packet.rr list * bool), error) result
   (** [response query] reads the responses which have arrived for [query].
       This function will block unless the caller has waited for events on the
       Unix domain socket.
+      If the response is [Ok (rrs, true)] then more results are expected so
+      the caller should wait on the Unix domain socket and call `response` again.
       This raises [Cancelled] if the query has been cancelled. *)
 
   val cancel: query -> unit

--- a/lib/osx_dnssd.c
+++ b/lib/osx_dnssd.c
@@ -199,7 +199,7 @@ static void common_callback(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t
   if (ocaml_f == NULL) abort();
   int c_token = *(int*)context;
   if (errorCode == kDNSServiceErr_NoError) {
-    record = caml_alloc(5, 0);
+    record = caml_alloc(6, 0);
     raw = caml_copy_string(fullname);
     Store_field(record, 0, raw);
     Store_field(record, 1, Val_int(rrtype));
@@ -208,6 +208,7 @@ static void common_callback(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t
     memcpy(String_val(raw), rdata, rdlen);
     Store_field(record, 3, raw);
     Store_field(record, 4, ttl);
+    Store_field(record, 5, Val_bool(flags & kDNSServiceFlagsMoreComing));
     result = caml_alloc(1, 0); /* Ok */
     Store_field(result, 0, record);
     caml_callback2(*ocaml_f, Val_int(c_token), result);

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -22,6 +22,14 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
+let test_srv () =
+  match Dnssd.(query "hugedns.test.dziemba.net" Dns.Packet.Q_SRV) with
+  | Error err -> failwith (Printf.sprintf "Error looking up SRV records for hugedns.test.dziemba.net: %s" (Dnssd.string_of_error err))
+  | Ok [] -> failwith "No SRV records found for hugedns.test.dziemba.net";
+  | Ok results ->
+    if List.length results <> 420
+    then failwith (Printf.sprintf "dig SRV hugedns.test.dziemba.net should return 420 records, but I got %d" (List.length results))
+
 let test_mx () =
   match Dnssd.(query "google.com" Dns.Packet.Q_MX) with
   | Error err -> failwith (Printf.sprintf "Error looking up MX records for google.com: %s" (Dnssd.string_of_error err))
@@ -48,6 +56,7 @@ let test_nomx () =
 
 let test_types = [
   "MX", `Quick, test_mx;
+  "SRV", `Quick, test_srv;
   "No MX", `Quick, test_nomx;
 ]
 


### PR DESCRIPTION
If the result set is large (> 1500 bytes?) then the callback is called with the `kDNSServiceFlagsMoreComing` flag set meaning that we should call `DNSServiceProcessResult` again to accumulate all the results.
