### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/dnssd.opam
+++ b/dnssd.opam
@@ -23,7 +23,7 @@ depends: [
   "logs"
   "fmt"
   "cstruct" {>= "2.3.0"}
-  "dune" {build}
+  "dune"
   "alcotest" {with-test}
 ]
 


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.